### PR TITLE
Update materials_sheets.dm

### DIFF
--- a/code/game/objects/structures/salvageable.dm
+++ b/code/game/objects/structures/salvageable.dm
@@ -118,6 +118,7 @@
 		/obj/item/stack/material/silver{amount = 10} = 20,
 		/obj/item/stack/material/gold{amount = 10} = 20,
 		/obj/item/stack/material/phoron{amount = 10} = 20,
+		/obj/item/stack/material/platinum[amount = 10} = 20,
 		/obj/item/stack/material/uranium{amount = 3} = 5,
 		/obj/item/stack/material/diamond{amount = 1} = 1
 	)

--- a/code/game/objects/structures/salvageable.dm
+++ b/code/game/objects/structures/salvageable.dm
@@ -118,7 +118,7 @@
 		/obj/item/stack/material/silver{amount = 10} = 20,
 		/obj/item/stack/material/gold{amount = 10} = 20,
 		/obj/item/stack/material/phoron{amount = 10} = 20,
-		/obj/item/stack/material/platinum[amount = 10} = 20,
+		/obj/item/stack/material/platinum[amount = 10} = 20,//Occulus Edit: Added platinum to the drop list
 		/obj/item/stack/material/uranium{amount = 3} = 5,
 		/obj/item/stack/material/diamond{amount = 1} = 1
 	)

--- a/code/modules/materials/material_sheets.dm
+++ b/code/modules/materials/material_sheets.dm
@@ -197,8 +197,8 @@
 /obj/item/stack/material/platinum/random
 	rand_min = 1
 	rand_max = 10
-	//spawn_tags = SPAWN_TAG_MATERIAL_RESOURCES_RARE
-	//rarity_value = 45
+	spawn_tags = SPAWN_TAG_MATERIAL_RESOURCES_RARE  //Occulus edit: Re-adding platinum glass to spawn pools
+	rarity_value = 45 //Occulus edit: Re-adding platinum glass to spawn pools
 
 //Extremely valuable to Research.
 /obj/item/stack/material/mhydrogen
@@ -320,8 +320,8 @@
 /obj/item/stack/material/glass/phoronglass/random
 	rand_min = 3
 	rand_max = 30
-	//spawn_tags = SPAWN_TAG_MATERIAL_RESOURCES_RARE
-	//rarity_value = 50
+	spawn_tags = SPAWN_TAG_MATERIAL_RESOURCES_RARE //Occulus edit: Re-adding phoron glass to spawn pools
+	rarity_value = 50 //Occulus edit: Re-adding phoron glass to spawn pools
 
 /obj/item/stack/material/glass/phoronrglass
 	name = "reinforced borosilicate glass"


### PR DESCRIPTION
## About The Pull Request

Re-enabled phoron glass and platinum spawning in maint.

## Why It's Good For The Game

Phoron Glass and Platinum can now be found in maint spawns

## Changelog
```changelog
balance: Phoron glass and platinum can be found in maint.
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
